### PR TITLE
Fixed controller and closing issues

### DIFF
--- a/xbox/nano/channel.py
+++ b/xbox/nano/channel.py
@@ -195,7 +195,7 @@ class AudioChannel(Channel):
         self.protocol.channel_open(flags, self.id)
 
     def on_close(self, flags):
-        raise NotImplementedError()
+        self.client.close()
 
     def client_handshake(self, audio_format):
         payload = factory.audio.client_handshake(
@@ -242,7 +242,7 @@ class ChatAudioChannel(Channel):
         self.protocol.channel_open(flags, self.id)
 
     def on_close(self, flags):
-        raise NotImplementedError()
+        self.client.close()
 
     def on_client_handshake(self, msg):
         log.debug("ChatAudioChannel client handshake", extra={'_msg': msg})
@@ -292,7 +292,7 @@ class InputChannel(Channel):
         self.protocol.channel_open(flags, self.id)
 
     def on_close(self, flags):
-        raise NotImplementedError()
+        pass
 
     def client_handshake(self, max_touches=10):
         payload = factory.input.client_handshake(

--- a/xbox/nano/factory/message.py
+++ b/xbox/nano/factory/message.py
@@ -6,7 +6,7 @@ STREAMER_VERSION = 3
 
 
 def header(payload_type, connection_id=0, channel_id=0, timestamp=0,
-           streamer=None, padding=False, **kwargs):
+           streamer=None, padding=False, sequence_num=0, **kwargs):
     """
     Helper method for creating a RTP header.
     """
@@ -15,6 +15,7 @@ def header(payload_type, connection_id=0, channel_id=0, timestamp=0,
             padding=padding,
             payload_type=payload_type
         ),
+        sequence_num=sequence_num,
         timestamp=timestamp,
         ssrc=Container(
             connection_id=connection_id,

--- a/xbox/nano/render/input/sdl.py
+++ b/xbox/nano/render/input/sdl.py
@@ -35,7 +35,7 @@ SDL_AXIS_MAP = {
     sdl2.SDL_CONTROLLER_AXIS_LEFTX: GamepadAxis.LeftThumbstick_X,
     sdl2.SDL_CONTROLLER_AXIS_LEFTY: GamepadAxis.LeftThumbstick_Y,
     sdl2.SDL_CONTROLLER_AXIS_RIGHTX: GamepadAxis.RightThumbstick_X,
-    sdl2.SDL_CONTROLLER_AXIS_RIGHTY: GamepadAxis.LeftThumbstick_Y
+    sdl2.SDL_CONTROLLER_AXIS_RIGHTY: GamepadAxis.RightThumbstick_Y
 }
 
 SDL_STATE_MAP = {

--- a/xbox/nano/render/input/sdl.py
+++ b/xbox/nano/render/input/sdl.py
@@ -102,4 +102,14 @@ class SDLInputHandler(InputHandler):
             elif event.type == sdl2.SDL_CONTROLLERAXISMOTION:
                 axis = event.caxis.axis
                 value = event.caxis.value
+                if axis in (sdl2.SDL_CONTROLLER_AXIS_LEFTY, sdl2.SDL_CONTROLLER_AXIS_RIGHTY):
+                    value = -value
+                if axis in (sdl2.SDL_CONTROLLER_AXIS_LEFTX, sdl2.SDL_CONTROLLER_AXIS_LEFTY, sdl2.SDL_CONTROLLER_AXIS_RIGHTX, sdl2.SDL_CONTROLLER_AXIS_RIGHTY):
+                    if value >= 32768:
+                        value = 32767
+                    elif value <= -32768:
+                        value = -32768
+                if axis in (sdl2.SDL_CONTROLLER_AXIS_TRIGGERLEFT, sdl2.SDL_CONTROLLER_AXIS_TRIGGERRIGHT):
+                    value = int(value / 32767 * 255)
+
                 self.set_axis(SDL_AXIS_MAP[axis], value)


### PR DESCRIPTION
Two things were fixed here:

* Some of the channels were triggering an exception when closing (copied from [@qsz13's fork](https://github.com/qsz13/xbox-smartglass-nano-python)).
* Missing `sequence_num` on some packets, which made the input not work at all.
* Y axis were inverted and all analog were overflowing when trying to send the packets, so I've (poorly, granted) limited them.

Tested on Xbox One S with client being Ubuntu 20.04 LTS and a Xbox 360 wireless controller through an USB adapter.